### PR TITLE
Migrate from Eleventy to Astro 5 with Vue 3 components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,240 +4,174 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Personal website and blog built with Eleventy (11ty) using JSX templates, Sass for styling, and deployed to Netlify. The site includes blog posts, notes, and a personal feed combining posts with reading highlights from Readwise.
+Personal website and blog built with **Astro 5.x**, **Vue 3** components, **Sass** for styling, and deployed to Netlify. The site includes blog posts, notes, and a personal feed combining posts with reading highlights from Readwise.
 
 ## Development Commands
 
 **Start development server:**
 ```bash
-yarn start
-# Runs Eleventy dev server on port 1995 with CSS watch mode
+npm run dev
+# or
+npm start
+# Runs Astro dev server on port 1995
 ```
 
 **Build for production:**
 ```bash
-yarn build
-# Cleans _site, builds CSS, runs Eleventy
+npm run build
+# Runs Astro static site build
 ```
 
-**CSS only:**
+**Preview production build:**
 ```bash
-yarn watch:css  # Watch mode
-yarn build:css  # One-time build
-```
-
-**Debug:**
-```bash
-yarn debug  # Run Eleventy with DEBUG=* for verbose output
+npm run preview
 ```
 
 ## Architecture
 
 ### Template System
 
-Uses JSX for most templates (via `jsx-async-runtime`), with Nunjucks for older templates. JSX is compiled to HTML by Eleventy plugin configured in `.eleventy.js:58-68`.
+Uses **Astro** (`.astro`) for layouts and pages, and **Vue 3 SFCs** (`.vue`) for presentational components. Astro files use JSX-like template syntax in the HTML section; Vue components use `<script setup lang="ts">` with TypeScript.
 
-**Layouts:**
-- `src/_includes/layouts/html.jsx` - Root HTML wrapper with fonts, meta tags
-- `src/_includes/layouts/base.jsx` - Base page layout with sidebar
-- `src/_includes/layouts/post.jsx` - Blog post layout
-- `src/_includes/layouts/note.njk` - Note layout (Nunjucks)
+**Layouts** (`src/layouts/`):
+- `HtmlLayout.astro` — Root HTML shell (head, meta tags, fonts, scripts)
+- `BaseLayout.astro` — Page chrome (Wrapper grid, Sidebar, header slot)
+- `PostLayout.astro` — Blog post pages (renders post nav, reply badge)
+- `NoteLayout.astro` — Note/wiki pages (renders TOC + article)
+- `PageLayout.astro` — Generic pages; supports both `.astro` imports and markdown `layout:` frontmatter
 
-**Main pages:**
-- `src/index.jsx` - Homepage with feed of posts/highlights
-- `src/archive.jsx` - Chronological post archive
-- `src/notes.njk` - Notes index
+**Main pages** (`src/pages/`):
+- `index.astro` — Homepage feed (first 40 items)
+- `[page].astro` — Paginated feed (pages 2+)
+- `[...slug].astro` — Individual blog posts, routed as `/{year}/{month}/{slug}/`
+- `[year]/index.astro` — Year archive pages
+- `notes/index.astro` — Notes index with tag filter
+- `notes/[slug].astro` — Individual note pages
+- `404.astro` — Error page
+- `backstage.astro` — Hidden drafts listing
+- `feed.xml.ts` — RSS feed endpoint
 
 ### Content Organization
 
-**Blog posts:** `posts/YYYY-MM-DD-slug.md` or `posts/YYYY-MM-DD-slug/index.md`
-- Frontmatter: `title`, `excerpt`, `image`, `featured`, `hidden`
-- Tagged with `posts`
-- Images in post directories are processed via markdown-it plugin
+All content lives in root-level directories, loaded via Astro content collections.
 
-**Notes:** `notes/*.md`
-- Simpler content structure
-- No date in filename
+**Blog posts** (`posts/*.md` or `posts/YYYY-MM-DD-slug/index.md`):
+- Filename convention: `YYYY-MM-DD-slug.md` — the date and slug are parsed from the filename, not frontmatter
+- Frontmatter: `title` (optional), `excerpt`, `image`, `featured`, `hidden`
+- Routes: `/{year}/{month}/{slug}/`
+
+**Notes** (`notes/*.md` or `notes/slug/index.md`):
+- Simpler content, no date convention
+- Frontmatter: `title`, `excerpt`, `tags`, `hidden`
+- Routes: `/notes/{slug}/`
 
 ### Data Layer
 
-`src/_data/` contains global data:
-- `metadata.json` - Site metadata (title, URL, author)
-- `books.js` - Reading list data
-- `highlights.js` - Readwise highlights (fetched via API)
-- `quotes.js` - Quote collection
-- `blogroll.js` - Links to other sites
+`src/data/` contains static data:
+- `metadata.json` — Site metadata (title, URL, author, feed config)
+- `books.ts` — Reading list data
+- `quotes.ts` — Quote collection
+- `blogroll.json` — Links to other sites (loaded as content collection)
+
+`src/content.config.ts` — Defines all content collections: `posts`, `notes`, `blogroll`, `highlights`.
+
+`src/utils/collections.ts` — Async helpers wrapping `getCollection()`:
+- `getPosts()` / `getVisiblePosts()` / `getFeaturedPosts()` — Posts with computed `date` and `permalink` fields
+- `getPostsByYear()` / `getYears()` — Archive helpers
+- `getNotes()` / `getVisibleNotes()` — Notes helpers
+- `getBlogroll()` / `getHighlights()` / `getFeed()` — Feed composition
+
+`src/utils/filters.ts` — Pure utility functions:
+- `readableDate`, `shortDate`, `htmlDateString`, `dateForXMLFeed` — Date formatting (UTC, via `date-fns`)
+- `getDateFromPostId`, `getSlugFromPostId`, `getPermalinkFromPost` — URL/slug computation from post IDs
+- `filterTagList` — Exclude system tags (`all`, `nav`, `post`, `posts`, `notes`)
+- `shouldShowCite` — Feed highlight citation grouping logic
+- `titleize`, `capitalize` — String helpers
 
 ### Collections
 
-Custom collections in `.eleventy.js`:
-- `postsByYear` - Posts grouped by year (excluding hidden)
-- `featuredPosts` - Posts with `featured: true`
-- `feed` - Combined posts + Readwise highlights sorted by date
-- `tagList` - All tags (filtered)
+The `highlights` collection is loaded dynamically at build time from a Cloudflare Worker API (`https://api.chsmc.workers.dev/highlights-feed`). If the fetch fails, it returns an empty array.
+
+The `feed` combines `getVisiblePosts()` + `getHighlights()` sorted by date, used for the homepage and paginated feed.
 
 ### Styling
 
-Sass files in `src/css/` compiled to `src/_includes/styles/`. Uses **BEM-Lite** naming convention.
+Sass files in `src/styles/` compiled by Astro. Uses **BEM-Lite** naming convention.
 
 **File structure:**
 ```
-src/css/
-├── styles.scss           # Main entry point
+src/styles/
+├── styles.scss           # Main entry point (imported in HtmlLayout.astro)
 ├── _reset.scss           # CSS reset
-├── _theme.scss           # Design tokens/variables
+├── _theme.scss           # Design tokens/variables (imported by Vue scoped styles)
 ├── _utilities.scss       # Utility classes
 ├── _prism.scss           # Syntax highlighting
 ├── base/
-│   ├── _elements.scss    # Global element defaults (html, body, a, etc.)
+│   ├── _elements.scss    # Global element defaults
 │   └── _typography.scss  # .prose utility for Markdown content
 ├── layout/
-│   ├── _Wrapper.scss     # Page wrapper grid
-│   ├── _Content.scss     # Main content area
-│   └── _Sidebar.scss     # Sidebar component
+│   ├── _Wrapper.scss
+│   ├── _Content.scss
+│   └── _Sidebar.scss
 └── components/
-    ├── _Article.scss     # Article/post content
-    ├── _Blog.scss        # Blog feed and pagination
-    ├── _SiteHeader.scss  # Site header and breadcrumbs
-    ├── _Callout.scss     # Callout boxes
-    ├── _Bookmark.scss    # book-mark custom element
-    └── _Archives.scss    # Archives listing
+    ├── _Article.scss
+    ├── _Blog.scss
+    ├── _SiteHeader.scss
+    ├── _Callout.scss
+    ├── _Bookmark.scss
+    └── _Archives.scss
 ```
+
+Vue SFCs use `<style scoped lang="scss">` with `@use '../styles/theme' as *` for design token access.
 
 **BEM-Lite naming convention:**
 - **Blocks**: UpperCamelCase (`.Wrapper`, `.Sidebar`, `.Blog`)
 - **Elements**: `Block__element` with camelCase (`.Sidebar__nav`, `.Blog__postPreview`)
 - **Modifiers**: `Block--modifier` with camelCase (`.Sidebar--mobile`, `.Blog--featured`)
 
-**Allowed nesting:**
-```scss
-.Sidebar__link {
-  // Pseudo-selectors OK
-  &:hover { }
-  &[aria-current="page"] { }
-}
-
-.Article {
-  // HTML elements OK for Markdown content
-  h1, h2, h3 { }
-  p { }
-  pre { }
-}
-```
-
 **Key classes:**
-- `.Wrapper` - Main page grid container
-- `.Wrapper__header` - Page header with site title
-- `.Wrapper__main` - Main content wrapper
-- `.Sidebar` / `.Sidebar--mobile` / `.Sidebar--desktop` - Sidebar variants
-- `.Content` - Main content area
-- `.Blog` / `.Blog--featured` / `.Blog--archive` - Blog feed variants
-- `.Article` - Article content wrapper
-- `.Pagination` - Post/page navigation
-- `.Breadcrumbs` - Breadcrumb navigation
-- `.SiteHeader` - Site title/logo
-- `.prose` - Typography utility for Markdown content (not a BEM block)
+- `.Wrapper` / `.Wrapper__header` / `.Wrapper__main` — Page grid container
+- `.Sidebar` / `.Sidebar--mobile` / `.Sidebar--desktop` — Sidebar variants
+- `.Content` — Main content area
+- `.Blog` / `.Blog--featured` / `.Blog--archive` — Blog feed variants
+- `.Article` — Article content wrapper (required for code block styling)
+- `.prose` — Typography utility for Markdown content
+- `.Breadcrumbs` — Breadcrumb navigation
+- `.SiteHeader` — Site title/logo
+- `.Pagination` — Post/page navigation
 
 **Utilities (no prefix):**
-- `.mb-{0,1,2,4,6,8,12,16,20,24,32,40,48}` - Margin-bottom
-- `.flex`, `.flex-column` - Flexbox
-- `.font-header`, `.serif`, `.sans`, `.mono` - Font families
-- `.color-accent`, `.color-caption` - Text colors
-- `.unstyled` - Reset links/lists
-- `.prose` - Markdown typography container
+- `.mb-{0,1,2,4,6,8,12,16,20,24,32,40,48}` — Margin-bottom
+- `.flex`, `.flex-column` — Flexbox
+- `.font-header`, `.serif`, `.sans`, `.mono` — Font families
+- `.color-accent`, `.color-caption` — Text colors
+- `.unstyled` — Reset links/lists
+- `.prose` — Markdown typography container
 
-Compiled CSS included via `html.jsx` layout from `src/_includes/styles/`.
+### Components (Vue SFCs)
 
-### Filters
+All Vue components are presentational (no client-side reactivity needed; rendered server-side during build):
 
-`utils/filters.js` exports Eleventy filters:
-- `readableDate`, `shortDate`, `htmlDateString` - Date formatting using date-fns with UTC
-- `groupByYear` - Group items by year
-- `filterHidden` - Exclude hidden posts
-- `filterTagList` - Exclude system tags
+- `Sidebar.vue` + `SidebarContent.vue` — Site sidebar (mobile uses `<details>` toggle)
+- `Highlight.vue` — Readwise highlight card with citation logic
+- `BlogPostPreview.vue` — Post preview link with title + date
+- `Pagination.vue` — Older/newer page nav for the feed
+- `PostNavigation.vue` — Previous/next post nav for individual posts
+- `ReplyBadge.vue` — "Reply via email" badge on post pages
+- `Archives.vue` — Featured posts + year list (used on 404 page)
 
-### Markdown Processing
+### URL Structure
 
-Custom markdown-it configuration with:
-- `markdown-it-anchor` - Auto-generate heading anchors
-- `utils/markdown-it-eleventy-img/` - Custom plugin for image processing with `@11ty/eleventy-img`
-- Images wrapped in `<figure>` with optional `<figcaption>` from title attribute
+Posts are routed by parsing the filename convention in `getStaticPaths`:
+- File: `posts/2024-01-15-my-post.md` → URL: `/2024/01/my-post/`
+- The `getDateFromPostId` and `getSlugFromPostId` helpers in `filters.ts` handle this parsing
 
-### Shortcodes
-
-**Slots system** (`.eleventy.js:72-86`): Allows child templates to inject content into parent layouts.
-```njk
-{% slot 'slotName', page.url %}content{% endslot %}
-```
-Access via `slots.slotName` in layouts.
-
-**Image shortcode:**
-```njk
-{% image src, alt, sizes %}
-```
-Generates responsive images with webp/jpg formats.
-
-### Static Assets
-
-- `public/` - Copied to site root (fonts, favicon, etc.)
-- `src/js/` - Copied to `/js` in output
-- Post images processed through markdown-it plugin to `_site/img/`
-
-## Template Patterns
-
-**Page layout structure (base.jsx):**
-```jsx
-<div class='Wrapper'>
-  <header class='Wrapper__header'>
-    <h1 class='SiteHeader'>...</h1>
-    <aside class='Sidebar Sidebar--mobile'>...</aside>
-  </header>
-  <main class='Wrapper__main'>
-    <div class='Content'>...</div>
-  </main>
-  <aside class='Sidebar Sidebar--desktop'>...</aside>
-</div>
-```
-
-**Blog post (post.jsx):**
-```jsx
-<article class='Article prose'>
-  {content}
-</article>
-<nav class='Pagination'>
-  <ul class='unstyled'>
-    <li class='Pagination__previous'>...</li>
-    <li class='Pagination__next'>...</li>
-  </ul>
-</nav>
-```
-
-**Blog feed (index.jsx):**
-```jsx
-<section class='Blog Blog--featured'>
-  <article class='prose Blog__article--longForm'>...</article>
-  <article class='Blog__article--highlight'>...</article>
-</section>
-```
-
-**Sidebar elements:**
-```jsx
-<div class='Sidebar__social'>...</div>
-<div class='Sidebar__blogroll'>...</div>
-<div class='Sidebar__years'>...</div>
-<nav class='Sidebar__nav'>...</nav>
-```
-
-**Common patterns:**
-- Combine BEM classes with utilities: `class='Blog__postPreview unstyled block'`
-- Use `.prose` for any Markdown-rendered content
-- Breadcrumbs: `<div class='Breadcrumbs'>...</div>`
-- Modifiers stack with base: `class='Sidebar Sidebar--mobile'`
-
-## Important Notes
+### Important Notes
 
 - Server runs on port 1995
-- Posts with `hidden: true` excluded from main collections but still built
+- Posts with `hidden: true` are excluded from main collections but still built (accessible via `/backstage`)
+- Notes with `hidden: true` are excluded from the notes index
 - Date handling uses `date-fns` with UTC timezone via `@date-fns/utc`
-- Template formats: md, njk, html, jsx (configured in `.eleventy.js:181`)
-- Output directory: `_site/`
+- Custom elements (e.g. `<now-playing>`, `<bookmark-list>`, `<filter-container>`) are excluded from Vue's component resolution via `isCustomElement: (tag) => tag.includes('-')` in `astro.config.mjs`
+- Output format: directory-based (`/foo/` not `/foo.html`)
+- The `BaseLayout` fetches sidebar data (`featuredPosts`, `years`, `blogroll`) internally — pages do not need to pass these as props

--- a/src/components/Highlight.vue
+++ b/src/components/Highlight.vue
@@ -49,14 +49,13 @@ defineProps<{
   color: var(--color-caption);
 
   cite {
-    font-size: 1em;
+    font-size: 0.9rem;
     font-style: normal;
     margin-bottom: 6px;
     color: var(--color-caption);
     display: flex;
     align-items: flex-start;
     gap: 6px;
-    font-size: 0.9rem;
     font-family: var(--font-code);
 
     @include small {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -10,8 +10,6 @@ const posts = defineCollection({
     featured: z.boolean().optional(),
     hidden: z.boolean().optional(),
     tags: z.array(z.string()).optional().default([]),
-    layout: z.string().optional(),
-    permalink: z.string().optional(),
   }),
 });
 
@@ -20,9 +18,8 @@ const notes = defineCollection({
   schema: z.object({
     title: z.string().optional(),
     excerpt: z.string().nullable().optional(),
+    hidden: z.boolean().optional(),
     tags: z.array(z.string()).optional().default([]),
-    layout: z.string().optional(),
-    permalink: z.string().optional(),
   }),
 });
 

--- a/src/layouts/HtmlLayout.astro
+++ b/src/layouts/HtmlLayout.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/styles.scss';
 import metadata from '../data/metadata.json';
+import { readableDate } from '../utils/filters';
 
 interface Props {
   title?: string;
@@ -16,16 +17,12 @@ const pageUrl = Astro.url.pathname;
 let pageTitle = metadata.title;
 if (title) {
   pageTitle = `${title} | ${metadata.title}`;
-} else if (pageUrl.includes('/posts/') || pageUrl.match(/\/\d{4}\/\d{2}\//)) {
-  // It's a post page
-  if (date) {
-    const { readableDate } = await import('../utils/filters');
-    pageTitle = `Note from ${readableDate(date)} | ${metadata.title}`;
-  }
+} else if (date && pageUrl.match(/\/\d{4}\/\d{2}\//)) {
+  pageTitle = `Note from ${readableDate(date)} | ${metadata.title}`;
 }
 
 const desc = description || metadata.description;
-const canonicalUrl = `https://chsmc.org${pageUrl}`;
+const canonicalUrl = `${metadata.url}${pageUrl}`;
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -66,7 +63,7 @@ const canonicalUrl = `https://chsmc.org${pageUrl}`;
     <meta property="og:site_name" content="Chase McCoy" />
     <meta property="og:url" content={canonicalUrl} />
     <meta property="og:title" content={pageTitle} />
-    <meta name="og:description" content={desc} />
+    <meta property="og:description" content={desc} />
     <meta name="twitter:creator" content="@chase_mccoy" />
     <meta name="twitter:title" content={pageTitle} />
     <meta property="fediverse:creator" content="@chsmc@mastodon.social" />

--- a/src/pages/[page].astro
+++ b/src/pages/[page].astro
@@ -3,7 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Highlight from '../components/Highlight.vue';
 import Pagination from '../components/Pagination.vue';
 import { getFeed } from '../utils/collections';
-import { htmlDateString, readableDate, shortDate } from '../utils/filters';
+import { htmlDateString, readableDate, shortDate, shouldShowCite } from '../utils/filters';
 import { render } from 'astro:content';
 
 export async function getStaticPaths() {
@@ -30,12 +30,6 @@ const { posts, pageNumber, totalPages } = Astro.props;
 
 const hasNextPage = pageNumber < totalPages;
 const hasPrevPage = pageNumber > 1;
-
-function shouldShowCite(post: any, index: number, posts: any[]) {
-  const isFirstInSequence = posts[index + 1]?.source?.title === post.source?.title && posts[index - 1]?.source?.title !== post.source?.title;
-  const isInSequence = posts[index - 1]?.source?.title === post.source?.title || posts[index + 1]?.source?.title === post.source?.title;
-  return isFirstInSequence || !isInSequence;
-}
 ---
 <BaseLayout templateClass="home">
   <section class="Blog Blog--featured">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,9 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import BlogPost from '../components/BlogPost.vue';
 import Highlight from '../components/Highlight.vue';
 import Pagination from '../components/Pagination.vue';
 import { getFeed } from '../utils/collections';
-import { htmlDateString, readableDate, shortDate } from '../utils/filters';
+import { htmlDateString, readableDate, shortDate, shouldShowCite } from '../utils/filters';
 import { render } from 'astro:content';
 
 const feed = await getFeed();
@@ -14,12 +13,6 @@ const reversedFeed = [...feed].reverse();
 const posts = reversedFeed.slice(0, PAGE_SIZE);
 const totalPages = Math.ceil(reversedFeed.length / PAGE_SIZE);
 const hasNextPage = totalPages > 1;
-
-function shouldShowCite(post: any, index: number, posts: any[]) {
-  const isFirstInSequence = posts[index + 1]?.source?.title === post.source?.title && posts[index - 1]?.source?.title !== post.source?.title;
-  const isInSequence = posts[index - 1]?.source?.title === post.source?.title || posts[index + 1]?.source?.title === post.source?.title;
-  return isFirstInSequence || !isInSequence;
-}
 ---
 <BaseLayout templateClass="home">
   <section class="Blog Blog--featured">

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -11,24 +11,14 @@ export function capitalize(string: string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
-export function groupByYear(items: any[]) {
-  const groups: Record<string, any[]> = {};
-  for (const item of items) {
-    const date = new Date(item.data?.date || item.date);
-    const year = date.getUTCFullYear().toString();
-    if (!groups[year]) groups[year] = [];
-    groups[year].push(item);
-  }
-  const keys = Object.keys(groups).sort().reverse();
-  const results: Record<string, any[]> = {};
-  keys.forEach((key) => (results[key] = groups[key]));
-  return results;
-}
-
-export function filterHidden(items: any[]) {
-  return items.filter((item) =>
-    item.data ? item.data.hidden !== true : true
-  );
+export function shouldShowCite(post: any, index: number, posts: any[]) {
+  const isFirstInSequence =
+    posts[index + 1]?.source?.title === post.source?.title &&
+    posts[index - 1]?.source?.title !== post.source?.title;
+  const isInSequence =
+    posts[index - 1]?.source?.title === post.source?.title ||
+    posts[index + 1]?.source?.title === post.source?.title;
+  return isFirstInSequence || !isInSequence;
 }
 
 export function readableDate(dateObj: Date | string) {


### PR DESCRIPTION
This PR completes the migration from Eleventy (11ty) with JSX templates to **Astro 5.x** with **Vue 3** components for presentational UI.

## Summary

The project has been refactored to use Astro as the static site generator, replacing Eleventy's JSX-based template system. Vue 3 SFCs are now used for reusable UI components, while Astro handles layouts, pages, and routing. The content structure and styling remain largely the same, with Sass compilation now handled by Astro.

## Key Changes

- **Framework migration**: Replaced Eleventy with Astro 5.x as the primary SSG
- **Template system**: 
  - Layouts converted from JSX to `.astro` files (`HtmlLayout.astro`, `BaseLayout.astro`, `PostLayout.astro`, etc.)
  - Presentational components migrated to Vue 3 SFCs (`Sidebar.vue`, `Highlight.vue`, `BlogPostPreview.vue`, `Pagination.vue`, etc.)
  - Astro handles file-based routing; posts use dynamic routes with filename-based date/slug parsing
  
- **Content collections**: 
  - Defined via `src/content.config.ts` with Zod schemas
  - Removed unused `layout` and `permalink` frontmatter fields (now computed via `getPermalinkFromPost()`)
  - Added `hidden` field to notes schema
  
- **Utilities refactored**:
  - Moved `shouldShowCite()` logic to `src/utils/filters.ts` (was inline in pages)
  - Removed `groupByYear()` and `filterHidden()` (replaced by collection helpers in `src/utils/collections.ts`)
  - Date formatting and URL computation helpers remain in `filters.ts`
  
- **Styling**: Sass files remain in `src/styles/` with same BEM-Lite conventions; Vue SFCs use scoped styles with `@use` imports for design tokens

- **Documentation**: Updated `CLAUDE.md` to reflect new architecture, file structure, and development commands

## Notable Implementation Details

- Custom elements (e.g., `<bookmark-list>`, `<now-playing>`) are excluded from Vue's component resolution via `isCustomElement` config
- The `BaseLayout` fetches sidebar data internally; pages don't need to pass these as props
- Posts are routed by parsing filename convention (`YYYY-MM-DD-slug.md` → `/{year}/{month}/{slug}/`)
- Highlights collection is fetched dynamically from a Cloudflare Worker API at build time
- Server runs on port 1995 (unchanged)
- Fixed OG meta tag property name (`og:description` → `property="og:description"`)

https://claude.ai/code/session_01VC6QzGYVA9LjkL1s5taSSD