### PR TITLE
Render full post content in RSS feed

### DIFF
--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -1,6 +1,7 @@
 import rss from '@astrojs/rss';
 import { getCollection, render } from 'astro:content';
-import { getDateFromPostId, getPermalinkFromPost, dateForXMLFeed } from '../utils/filters';
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { getDateFromPostId, getPermalinkFromPost } from '../utils/filters';
 import metadata from '../data/metadata.json';
 
 export async function GET(context: any) {
@@ -15,15 +16,26 @@ export async function GET(context: any) {
     .filter(p => p.date)
     .sort((a, b) => b.date!.getTime() - a.date!.getTime());
 
+  const container = await AstroContainer.create();
+
+  const items = await Promise.all(
+    visiblePosts.map(async (post) => {
+      const { Content } = await render(post);
+      const content = await container.renderToString(Content);
+      return {
+        title: post.data.title || `Note from ${post.date!.toISOString().split('T')[0]}`,
+        pubDate: post.date!,
+        link: post.permalink,
+        content,
+      };
+    })
+  );
+
   return rss({
     title: metadata.title,
     description: metadata.feed.subtitle,
     site: metadata.url,
-    items: visiblePosts.map(post => ({
-      title: post.data.title || `Note from ${post.date!.toISOString().split('T')[0]}`,
-      pubDate: post.date!,
-      link: post.permalink,
-    })),
+    items,
     customData: `<language>${metadata.language}</language>`,
   });
 }


### PR DESCRIPTION
Uses AstroContainer.renderToString() to produce the HTML string for each post's content:encoded element. Previously the feed only included titles and links; render was imported but never called.

Also removes the unused dateForXMLFeed import.

https://claude.ai/code/session_01VC6QzGYVA9LjkL1s5taSSD